### PR TITLE
Animate using css instead of liquid fire

### DIFF
--- a/addon/utils/animation.js
+++ b/addon/utils/animation.js
@@ -1,0 +1,64 @@
+// Thanks ember-css-transitions
+// https://github.com/peec/ember-css-transitions/blob/master/addon/mixins/transition-mixin.js
+
+import { run } from '@ember/runloop';
+import RSVP from 'rsvp';
+import Ember from 'ember';
+const { testing } = Ember;
+/**
+ * @private
+ * T (period) = 1 / f (frequency)
+ * TICK = 1 / 60hz = 0,01667s = 17ms
+ */
+const TICK = 17;
+
+/**
+ * @public
+ * This function performs some logic after a browser repaint.
+ * While on testing or if raf not available, use a run-loop friendly equivalent.
+ * This also makes the tests work as expected.
+ */
+export const rAF = testing || !window.requestAnimationFrame ? function(fn) {
+  return run.later(fn, TICK);
+} : window.requestAnimationFrame;
+
+/**
+ * @public
+ * Performs some logic after DOM changes have been flushed
+ * and after a browser repaint.
+ */
+export function nextTick() {
+  return new RSVP.Promise((resolve) => {
+    run.schedule('afterRender', () => {
+      rAF(() => {
+        resolve();
+      });
+    });
+  });
+}
+
+/**
+ * @private
+ * Computes the time a css animation will take.
+ * Uses `getComputedStyle` to get durations and delays.
+ */
+export function computeTimeout(element) {
+  let {
+    transitionDuration,
+    transitionDelay,
+    animationDuration,
+    animationDelay,
+    animationIterationCount
+  } = window.getComputedStyle(element);
+
+  // `getComputedStyle` returns durations and delays in the Xs format.
+  // Conveniently if `parseFloat` encounters a character other than a sign (+ or -),
+  // numeral (0-9), a decimal point, or an exponent, it returns the value up to that point
+  // and ignores that character and all succeeding characters.
+
+  let maxDelay = Math.max(parseFloat(animationDelay), parseFloat(transitionDelay));
+  let maxDuration = Math.max(parseFloat(animationDuration) *
+    parseFloat(animationIterationCount), parseFloat(transitionDuration));
+
+  return (maxDelay + maxDuration) * 1000;
+}

--- a/app/styles/nav-stack.scss
+++ b/app/styles/nav-stack.scss
@@ -1,21 +1,28 @@
 $nav-stack-header-height: 44px;
 $nav-stack-footer-height: 50px;
 
+$easing: cubic-bezier(.23, 1, .32, 1);
+
 .NavStack {
   position: absolute;
   left: 0px;
   top: 0;
   width: 100%;
   height: 100%;
+  transition: transform 600ms $easing;
+
+  .isCutting {
+    transition-duration: 0ms !important;
+  }
 
   &--layer0 {
-    top: 0;
+    transform: translateY(0);
   }
   &--layer1 {
-    top: 100%;
+    transform: translateY(100%);
   }
   &--layer2 {
-    top: 200%;
+    transform: translateY(200%);
   }
   &-itemContainer {
     position: absolute;
@@ -23,6 +30,7 @@ $nav-stack-footer-height: 50px;
     bottom: 0;
     left: 0;
     width: 500%;
+    transition: transform 300ms $easing;
   }
 
   &-item {
@@ -78,13 +86,12 @@ $nav-stack-footer-height: 50px;
     width: $item-width;
     height: $item-height;
 
-
     &.NavStack--layer1 {
-      top: $item-height;
+      transform: translateY($item-height);
     }
 
     &.NavStack--layer2 {
-      top: $item-height * 2;
+      transform: translateY($item-height * 2);
     }
 
     .NavStack-itemContainer {
@@ -95,19 +102,5 @@ $nav-stack-footer-height: 50px;
     .NavStack-item {
       border: 1px dashed blue;
     }
-
-    .NavStack--layer0 .NavStack-itemContainer {
-      border: 1px solid green;
-      background: rgba(lighten(green, 50%), 0.9);
-    }
-    .NavStack--layer1 .NavStack-itemContainer {
-      border: 1px solid yellow;
-      background: rgba(lighten(yellow, 30%), 0.9);
-    }
-    .NavStack--layer2 .NavStack-itemContainer {
-      border: 1px solid purple;
-      background: rgba(lighten(purple, 50%), 0.9);
-    }
-
   }
 }

--- a/app/utils/animation.js
+++ b/app/utils/animation.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-nav-stack/utils/animation';


### PR DESCRIPTION
I couldn't help myself. I wanted to dive into some of this on my own and to give css animations a stab. 

After looking at ember-css-transitions a little more, I realized that had an ingenious solution to our animation end callback issues. The inspects the computed style of the element and looks at the transitions and animations duration to set a timeout for the length for the callback. 

It's hard to get real FPS testing for this change as things are so small. I'd like to do some more work making sure each NavStack is rendered on it's own composite layer ensuring we get the maximum benefit out of GPU renders. 