### PR TITLE
Android 4 compatibility

### DIFF
--- a/addon/utils/animation.js
+++ b/addon/utils/animation.js
@@ -63,16 +63,14 @@ export function computeTimeout(element) {
   return (maxDelay + maxDuration) * 1000;
 }
 
-const TRANSFORM_STYLE_KEYS = [
-  "webkitTransform",
-  "mozTransform",
-  "msTransform",
-  "oTransform",
-  "transform"
-];
-export function setTransformTranslateStyle(element, plane, amount) {
-  let transformValue = `translate${plane}(${amount})`;
-  TRANSFORM_STYLE_KEYS.forEach((transformKey) => {
-    element.style[transformKey] = transformValue;
-  });
+let setTransformImpl = function setTransformFunc(element, value) {
+  element.style.transform = value;
 }
+// Android <= 4.x does not support element.style.transform
+if (document.body.style.transform === undefined) {
+  setTransformImpl = function setTransformFunc(element, value) {
+    element.style.webkitTransform = value;
+  }
+}
+
+export let setTransform = setTransformImpl;

--- a/addon/utils/back-swipe-recognizer.js
+++ b/addon/utils/back-swipe-recognizer.js
@@ -72,7 +72,7 @@ export default class BackSwipeRecognizer extends Hammer.Pan {
     if (DEBUG) {
       let testingEl = document.querySelector('#ember-testing');
       if (testingEl) {
-        let minValidX = testingEl.getBoundingClientRect().x;
+        let minValidX = testingEl.getBoundingClientRect().left;
         let maxValidX = minValidX + (testingEl.clientWidth * (this.options.validLeftAreaPercent/100));
         return inputData.center.x >= minValidX && inputData.center.x <= maxValidX;
       }


### PR DESCRIPTION
- Android 4 does not support element.style.transform, so we fallback to element.style.webkitTransform
- Android 4's element.getBoundingClientRect() return value does not have .x and .y properties, so we use .left and .right