### PR TITLE
Better handling for case where nav stack is unrendered then re-rendered

### DIFF
--- a/addon/components/nav-stack/component.js
+++ b/addon/components/nav-stack/component.js
@@ -132,7 +132,7 @@ export default class NavStack extends Component {
       ]
     });
     let isInitialRender = this.navStacksService.isInitialRender;
-    scheduleOnce('afterRender', this, this.handleStackDepthChange, isInitialRender);
+    scheduleOnce('afterRender', this, this.handleStackDepthChange, isInitialRender, !isInitialRender);
     this._setupPanHandlerContext();
 
     let { hammer, gesture } = this;
@@ -149,17 +149,17 @@ export default class NavStack extends Component {
 
   @action
   stackItemsDidChange() {
-    this.handleStackDepthChange(false);
+    this.handleStackDepthChange(false, false);
   }
 
-  handleStackDepthChange(isInitialRender) {
+  handleStackDepthChange(isInitialRender, isRerender) {
     let stackItems = this.stackItems || [];
     let stackDepth = stackItems.length;
     let rootComponentRef = stackItems[0] && stackItems[0].component;
     let rootComponentKey = this.args.extractComponentKey ? this.args.extractComponentKey(rootComponentRef) : extractComponentKey(rootComponentRef);
 
     let layer = this.args.layer;
-    if (isInitialRender) {
+    if (isInitialRender || isRerender) {
       this.schedule(this.cut);
     }
 

--- a/addon/components/nav-stack/component.js
+++ b/addon/components/nav-stack/component.js
@@ -251,6 +251,7 @@ export default class NavStack extends Component {
 
   slideUp() {
     let debug = this.birdsEyeDebugging;
+    this.repositionX();
     this.verticalTransition({
       element: this.element,
       toValue: 0,


### PR DESCRIPTION
- Detect when re-rendering a previously rendered stack and use a cut transition
- Reposition viewport before performing slideUp transition

Before this change, the `postMessage` navigations could result in the preview window performing a slide up transition to the More page instead of the page itself. This fixes the slide up transition, but also switches to the more appropriate cut transition.